### PR TITLE
feat: Add terminall-bell and silence options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Add terminal-bell and silence options(#66)
+
 ## [v0.3.5](https://github.com/pando85/timer/tree/v0.3.5) - 2022-08-15
 
 ### Fixed
 
-* Added `pkg-config` to AUR build dependencies(#62)
+* Add `pkg-config` to AUR build dependencies(#62)
 
 ## [v0.3.4](https://github.com/pando85/timer/tree/v0.3.4) - 2022-08-15
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,19 @@
 
 Simple count down terminal alarm.
 
+- [Features](#features)
+- [Installation](#installation)
+  - [Cargo](#cargo)
+  - [Archlinux](#archlinux)
+  - [Binaries](#binaries)
+- [Beep](#beep)
+- [Terminal bell](#terminal-bell)
+
 ## Features
 
 - Multiple input options
 - Play sound when finished (Beep included!)
+- Send terminal bell
 - Big centered output
 
 ## Installation
@@ -59,3 +68,18 @@ If you want to enable beep from your built-in case speaker you will need to run 
 kernel modules: `pcspkr` (recommended) or `snd-pcsp`.
 
 In addition, to use beep as normal user read the [`PERMISSIONS.md`](PERMISSIONS.md) file.
+
+## Terminal bell
+
+If executed with `-t, --terminal-bell` option it will send a bell character. Same as:
+
+```bash
+echo -e '\a'
+```
+
+This is useful for visual bell. Remember that you have to enable it in your terminal configuration.
+Usage example:
+
+```bash
+timer -t -s 11:00
+```

--- a/timer_core/src/bin/timer.rs
+++ b/timer_core/src/bin/timer.rs
@@ -1,4 +1,5 @@
 use timer_core::beep::beep;
+use timer_core::opts::Opts;
 use timer_core::timer;
 use timer_core::ui;
 
@@ -7,24 +8,9 @@ use std::process::exit;
 use std::thread;
 use std::time::Duration;
 
-use clap::{crate_authors, crate_description, crate_version, IntoApp, Parser};
+use clap::{IntoApp, Parser};
 use signal_hook::{consts::signal::*, iterator::Signals};
 use time::OffsetDateTime;
-
-#[derive(Parser)]
-#[clap(
-    name="timer",
-    about = crate_description!(),
-    version = crate_version!(),
-    author = crate_authors!("\n"),
-)]
-struct Opts {
-    /// Remaining time until the alarm sounds. Format: `%Hh %Mm %Ss`.
-    /// It also supports `min` for minutes or empty for seconds.
-    /// In addition, it supports a target time `%H:%M`. E.g.: 10s, 12:00, 3h10m, 15min, 10.
-    #[clap(multiple_occurrences = true, takes_value = true, number_of_values = 1)]
-    time: Vec<String>,
-}
 
 fn main() {
     let opts: Opts = Opts::parse();
@@ -52,7 +38,7 @@ fn main() {
     ui::set_up_terminal(&mut stdout).unwrap();
 
     let thread_join_handle = thread::spawn(move || {
-        match timer::countdown(&mut stdout, end) {
+        match timer::countdown(&mut stdout, end, &opts) {
             Ok(_) => {
                 ui::restore_terminal(&mut stdout).unwrap();
             }

--- a/timer_core/src/lib.rs
+++ b/timer_core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod beep;
 pub mod constants;
 pub mod figlet;
+pub mod opts;
 pub mod sound;
 mod time;
 pub mod timer;

--- a/timer_core/src/opts.rs
+++ b/timer_core/src/opts.rs
@@ -1,0 +1,22 @@
+use clap::{crate_authors, crate_description, crate_version, Parser};
+
+#[derive(Parser)]
+#[clap(
+    name="timer",
+    about = crate_description!(),
+    version = crate_version!(),
+    author = crate_authors!("\n"),
+)]
+pub struct Opts {
+    /// Disable playing sounds
+    #[clap(short, long)]
+    pub silence: bool,
+    /// Enable terminal bell (useful for visual bell)
+    #[clap(short, long)]
+    pub terminal_bell: bool,
+    /// Remaining time until the alarm sounds. Format: `%Hh %Mm %Ss`.
+    /// It also supports `min` for minutes or empty for seconds.
+    /// In addition, it supports a target time `%H:%M`. E.g.: 10s, 12:00, 3h10m, 15min, 10.
+    #[clap(multiple_occurrences = true, takes_value = true, number_of_values = 1)]
+    pub time: Vec<String>,
+}

--- a/timer_core/src/time.rs
+++ b/timer_core/src/time.rs
@@ -83,7 +83,7 @@ impl Time {
                 Some(s) => s,
                 None => match self.try_render(size, true, true, true) {
                     Some(s) => s,
-                    // safe unwrap: if is centered return string without figlet
+                    // safe unwrap: if is not centered return string without figlet
                     None => self.try_render(size, false, false, false).unwrap(),
                 },
             },


### PR DESCRIPTION
This will be useful for people that prefers visual bell. E.g.:
```
timer -t -s 12:00
```

Resolves #58