### PR TITLE
build(ci): Fix cargo login token

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,7 +119,7 @@ jobs:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         shell: bash
         run: |
-          cargo login "${CRATES_IO_TOKEN}"
+          echo "${CRATES_IO_TOKEN}" | cargo login
           make publish
 
       - name: Get Changelog Entry


### PR DESCRIPTION
```
cargo login <token>` is deprecated in favor of reading `<token>` from stdin
```