### PR TITLE
fix(ci): Handle shallow clones in release script

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 set -e
 
-if ! [ "$(git rev-list --count origin/master..HEAD)" -eq 0 ]; then
+ensure_full_history() {
+    if git rev-parse --is-shallow-repository 2>/dev/null | grep -q "true"; then
+        echo "Shallow clone detected. Fetching full history and tags..."
+        git fetch --unshallow --quiet
+    fi
+    if [ -z "$(git tag -l)" ]; then
+        echo "No tags found. Fetching tags..."
+        git fetch --tags --quiet
+    fi
+}
+
+ensure_full_history
+
+if ! [ "$(git rev-list --count origin/master..HEAD 2>/dev/null || echo 1)" -eq 0 ]; then
     echo "There are commits in this branch. Please merge them first."
     echo "CHANGELOG template needs master commit ID."
     exit 1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,13 @@
 .ci/release.sh
 ```
 
+This script **automatically**:
+1. Detects and fixes shallow clones (fetches full history + tags)
+2. Bumps version in `Cargo.toml`
+3. Updates the lock file
+4. Runs `make update-changelog`
+5. Creates a release commit
+
 ## Upgrade dependencies
 
 Requirements:


### PR DESCRIPTION
## Summary

- Add `ensure_full_history()` function to `.ci/release.sh` that detects shallow clones (e.g. CI with `fetch-depth: 1`) and automatically fetches full history and tags
- This prevents CHANGELOG generation failures when git-cliff or other tools need full commit history
- Update `RELEASE.md` to document what the release script does automatically

## Changes

- `.ci/release.sh`: Added `ensure_full_history` function that unshallows repos and fetches tags before any git operations
- `RELEASE.md`: Added documentation of script's automatic steps including shallow clone handling

Same fix pattern as applied in forkline/ingress-nginx repo.